### PR TITLE
Require custom fields on verification

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -57,9 +57,9 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   def user_exists_in_census
     if !CensusClient.person_exists?(document_number, formatted_birthdate, postal_code)
       errors.add(:wadus, 'wadus')
-    else
-      user.telephone_number_custom = telephone_number_custom
-      user.official_name_custom = official_name_custom
+    elsif [telephone_number_custom, official_name_custom].any?(&:present?)
+      user.telephone_number_custom = telephone_number_custom if telephone_number_custom.present?
+      user.official_name_custom = official_name_custom if official_name_custom.present?
       user.save!
     end
   end
@@ -71,7 +71,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   def telephone_number_custom_format
     return unless user.telephone_number_custom.blank?
 
-    self.telephone_number_custom = telephone_number_custom.gsub(NORMALIZE_TELEPHONE_REGEXP, "")
+    self.telephone_number_custom = telephone_number_custom.to_s.gsub(NORMALIZE_TELEPHONE_REGEXP, "")
 
     unless TELEPHONE_NUMBER_REGEXP =~ telephone_number_custom
       errors.add(:telephone_number_custom, I18n.t("custom_errors.telephone_format"))

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -56,7 +56,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
   def user_exists_in_census
     if !CensusClient.person_exists?(document_number, formatted_birthdate, postal_code)
-      errors.add(:wadus, 'wadus')
+      errors.add(:person_exists_in_census, 'person_exists_in_census')
     elsif [telephone_number_custom, official_name_custom].any?(&:present?)
       user.telephone_number_custom = telephone_number_custom if telephone_number_custom.present?
       user.official_name_custom = official_name_custom if official_name_custom.present?

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -4,15 +4,29 @@ require 'census_client'
 
 class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
+  TELEPHONE_NUMBER_REGEXP = /^\d{9,}$/
+  NORMALIZE_TELEPHONE_REGEXP = /\.|\ |\-|\_/
+
   attribute :document_number, String
   attribute :postal_code, String
   attribute :date_of_birth, Date
+  attribute :official_name_custom, String
+  attribute :telephone_number_custom, String
 
   validates :date_of_birth, presence: true
   validates :document_number, presence: true
   validates :postal_code, presence: true, format: { with: /\A[0-9]*\z/ }, length: { is: 5 }
 
-  validate :user_exists_in_census
+  validates :official_name_custom, presence: true, length: { minimum: 3 }, if: ->(form) do
+    form.user.official_name_custom.blank?
+  end
+  validates :telephone_number_custom, presence: true, if: ->(form) do
+    form.user.telephone_number_custom.blank?
+  end
+  validate :telephone_number_custom_format
+
+  validate :user_exists_in_census # must be declared as the last validation so custom
+                                  # fields are not saved unless census call succeeds
 
   def self.from_params(params, additional_params = {})
     instance = super(params, additional_params)
@@ -43,11 +57,25 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   def user_exists_in_census
     if !CensusClient.person_exists?(document_number, formatted_birthdate, postal_code)
       errors.add(:wadus, 'wadus')
+    else
+      user.telephone_number_custom = telephone_number_custom
+      user.official_name_custom = official_name_custom
+      user.save!
     end
   end
 
   def formatted_birthdate
     date_of_birth.strftime('%d/%m/%Y') if date_of_birth.present?
+  end
+
+  def telephone_number_custom_format
+    return unless user.telephone_number_custom.blank?
+
+    self.telephone_number_custom = telephone_number_custom.gsub(NORMALIZE_TELEPHONE_REGEXP, "")
+
+    unless TELEPHONE_NUMBER_REGEXP =~ telephone_number_custom
+      errors.add(:telephone_number_custom, I18n.t("custom_errors.telephone_format"))
+    end
   end
 
 end

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -1,3 +1,9 @@
+<% if current_user.official_name_custom.blank? %>
+  <div class="field">
+    <%= form.text_field :official_name_custom, help_text: t("decidim.devise.registrations.new.official_name_custom_help") %>
+  </div>
+<% end %>
+
 <div class="field">
   <%= form.text_field :document_number %>
 </div>
@@ -5,6 +11,12 @@
 <div class="field date">
   <%= form.date_select :date_of_birth, start_year: 1900, end_year: 16.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
 </div>
+
+<% if current_user.telephone_number_custom.blank? %>
+  <div class="field">
+    <%= form.text_field :telephone_number_custom, help_text: t("decidim.devise.registrations.new.telephone_number_custom_help") %>
+  </div>
+<% end %>
 
 <div class="field">
   <%= form.text_field :postal_code %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -5,7 +5,9 @@ ca:
       census_authorization_handler:
         date_of_birth: Data de naixement
         document_number: Número del document d'identitat (DNI o NIE sense la lletra final)
+        official_name_custom: Nom oficial
         postal_code: Codi postal
+        telephone_number_custom: Telèfon personal
       user:
         official_name_custom: Nom oficial
         telephone_number_custom: Telèfon personal

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,7 +5,9 @@ es:
       census_authorization_handler:
         date_of_birth: Fecha de nacimiento
         document_number: Número del documento de identidad (DNI o NIE sin la letra final)
+        official_name_custom: Nombre oficial
         postal_code: Código postal
+        telephone_number_custom: Teléfono personal
       user:
         official_name_custom: Nombre oficial
         telephone_number_custom: Teléfono personal

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -20,10 +20,13 @@ describe CensusAuthorizationHandler do
       postal_code: postal_code
     }
   end
+  let(:official_name) { "Napoleón Bonaparte" }
+  let(:telephone_number) { "123456789" }
 
   it_behaves_like "an authorization handler"
 
   before do
+    user.update_attributes!(official_name_custom: official_name, telephone_number_custom: telephone_number)
     allow_any_instance_of(Savon::Client).to receive(:call).and_return(
       OpenStruct.new(body: { validarpadro_decidim_response: { result: "0" } })
     )

--- a/spec/system/verification_spec.rb
+++ b/spec/system/verification_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails_helper"
+require "census_client"
+
+describe "Verification", type: :system do
+  let(:organization) { build :organization, available_authorizations: ["census_authorization_handler"] }
+  let(:user) { create(:user, :confirmed, password: password, password_confirmation: password, organization: organization) }
+  let(:password) { "dqCFgjfDbC7dPbrv" }
+  let(:official_name) { "Napoleón Bonaparte" }
+  let(:telephone_number) { "123456789" }
+
+  def fill_in_authorization_form(options = {})
+    fill_in "authorization_handler[document_number]", with: "12345678"
+    select "12", from: "authorization_handler_date_of_birth_3i"
+    select "January", from: "authorization_handler_date_of_birth_2i"
+    select "1979", from: "authorization_handler_date_of_birth_1i"
+    fill_in "authorization_handler[postal_code]", with: "12345"
+
+    if options[:with_custom_fields]
+      fill_in "authorization_handler[official_name_custom]", with: official_name
+      fill_in "authorization_handler[telephone_number_custom]", with: "123 456.789"
+    end
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim.account_path
+    click_link "Authorizations"
+  end
+
+  context "when user is registered in census" do
+
+    before do
+      allow(CensusClient).to receive(:person_exists?).and_return(true)
+    end
+
+    describe "when official name and telephone number are missing" do
+      it "sets them and creates the authorization" do
+        click_link "Padró municipal"
+
+        fill_in_authorization_form(with_custom_fields: true)
+
+        click_button "Autoritzar"
+
+        expect(page).to have_content("You've been successfully authorized")
+
+        user.reload
+
+        expect(user.official_name_custom).to eq(official_name)
+        expect(user.telephone_number_custom).to eq(telephone_number)
+        expect(::Decidim::Authorization.exists?(decidim_user_id: user.id)).to be_truthy
+      end
+    end
+
+    describe "when official name and telephone number are already set" do
+      before do
+        user.update_attributes!(official_name_custom: official_name, telephone_number_custom: telephone_number)
+      end
+
+      it "creates the authorization" do
+        click_link "Padró municipal"
+
+        refute has_field? "authorization_handler[official_name_custom]"
+        refute has_field? "authorization_handler[telephone_number_custom]"
+
+        fill_in_authorization_form
+
+        click_button "Autoritzar"
+
+        expect(page).to have_content("You've been successfully authorized")
+
+        user.reload
+
+        expect(::Decidim::Authorization.exists?(decidim_user_id: user.id)).to be_truthy
+      end
+    end
+
+  end
+
+  context "when user is not registered in census" do
+
+    before do
+      allow(CensusClient).to receive(:person_exists?).and_return(false)
+    end
+
+    it "rejects the authorization and does not update custom fields" do
+      click_link "Padró municipal"
+
+      fill_in_authorization_form(with_custom_fields: true)
+
+      click_button "Autoritzar"
+
+      expect(page).to have_content("There was an error creating the authorization")
+
+      user.reload
+
+      expect(user.official_name_custom).to be_nil
+      expect(user.telephone_number_custom).to be_nil
+      expect(::Decidim::Authorization.exists?(decidim_user_id: user.id)).to be_falsey
+    end
+
+  end
+
+end

--- a/spec/system/verification_spec.rb
+++ b/spec/system/verification_spec.rb
@@ -74,6 +74,8 @@ describe "Verification", type: :system do
 
         user.reload
 
+        expect(user.official_name_custom).to eq(official_name)
+        expect(user.telephone_number_custom).to eq(telephone_number)
         expect(::Decidim::Authorization.exists?(decidim_user_id: user.id)).to be_truthy
       end
     end


### PR DESCRIPTION
Modifies the verification form so it is compulsory to add the telephone number and official name before verificating against the census.

To test this in `staging` you'll have to manually edit the `CensusClient` to fake error/success calls. You can do it with:

```bash
vim /var/www/decidim/current/lib/census_client.rb
# add "return true" or "return false" in the first line of the "person_exists?" method
touch /var/www/decidim/current/tmp/restart.txt
```

For the login you can user `user-2@example.com` / `decidim123456`. The access to the verification form is in `/authorizations/new?handler=census_authorization_handler`.

**Things you may check**

* If the telephone number and official name already exist, they are not requested in the form.
* If the telephone number and official name already exist, they are not "nullified" if the verification succeeds.
* If the validations against the census fails, the telephone number and official name are not saved.
