### PR TITLE
Restore header searchbox

### DIFF
--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -26,6 +26,7 @@
                 <%= image_tag('logo-reus-negatiu.png', alt: 'Ayuntamiento de Reus') %>
               </a>
             </div>
+            <%= render partial: "layouts/decidim/topbar_search" %>
             <%= render partial: "layouts/decidim/language_chooser" %>
             <div class="hide-for-medium topbar__menu">
               <button type="button" data-toggle="offCanvas">


### PR DESCRIPTION
We overrode the `_wrapper.html.erb` for the custom site theme, so we the search was added to this header in the core, we lost it. This PR restores the searchbox.

We need to manually trigger the reindex for existing proposals in the server:

```ruby
Decidim::Proposals::Proposal.find_each(&:add_to_index_as_search_resource)
```