### PR TITLE
Add Rack::Attack configuration to application config file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,3 +18,11 @@ module DecidimApplication
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "*.{yml}")]
   end
 end
+
+Decidim.configure do |config|
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
+  config.throttling_max_requests = 1000
+
+  # Time window in which the throttling is applied.
+  # config.throttling_period = 1.minute
+end


### PR DESCRIPTION
Related to https://github.com/PopulateTools/issues/issues/1473

This PR changes configuration of Rack::Attack and raises the throttling_max_requests to 1000