### PR TITLE
Update initializer maps block

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -8,11 +8,10 @@ Decidim.configure do |config|
 
   # Geocoder configuration
 
-  config.geocoder = {
-    static_map_url: "https://image.maps.cit.api.here.com/mia/1.6/mapview",
-    here_app_id: Rails.application.secrets.geocoder[:here_app_id],
-    here_app_code: Rails.application.secrets.geocoder[:here_app_code],
-    here_api_key: Rails.application.secrets.geocoder[:here_api_key]
+  config.maps = {
+    provider: :here,
+    api_key: Rails.application.secrets.maps[:api_key],
+    static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
   }
 
   # Custom resource reference generator method

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -25,10 +25,8 @@ default: &default
       enabled: false
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
-  geocoder:
-    here_app_id: <%= ENV["GEOCODER_LOOKUP_APP_ID"] %>
-    here_app_code: <%= ENV["GEOCODER_LOOKUP_APP_CODE"] %>
-    here_api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
+  maps:
+    api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
   mailer_sender: "no-reply@decidim.dev"
 
 development:


### PR DESCRIPTION
This PR updates the maps block in Decidim initializer according to the docs:

- replaces geocoder by maps
- users just the api key