### PR TITLE
Ignore AS::Invariable exception in Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -7,7 +7,8 @@ Rollbar.configure do |config|
     "ActionController::InvalidCrossOriginRequest" => "ignore",
     "ActionController::RoutingError" => "ignore",
     "ActionController::UnknownFormat" => "ignore",
-    "ActiveRecord::RecordNotFound" => "info"
+    "ActiveRecord::RecordNotFound" => "info",
+    "ActiveStorage::InvariableError" => "ignore"
   )
 
   config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env


### PR DESCRIPTION
This PR ignores rollbar notifications for ActiveStorage::Invariable exception while we investigate the reason.