### PR TITLE
Remove the contact link from the footer

### DIFF
--- a/app/overrides/layouts/decidim/_main_footer/pre_main_footer.html.erb.deface
+++ b/app/overrides/layouts/decidim/_main_footer/pre_main_footer.html.erb.deface
@@ -45,7 +45,6 @@
       <div class="medium-6 small-12 columns">
         <p>
           <a class="pr-2" href="http://www.reus.cat" target="_blank" title="<%= t('.reus_link_title') %>">Reus.cat</a>.
-          <a class="pr-2" href="http://www.reus.cat/contacta" target="_blank" title="contacta amb l'Ajuntament de Reus"><%= t('.contact') %></a>.
         </p>
         <hr>
         <small><%= t('.city_council_address') %><br>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1779

- Remove the contact link from the footer

cc @aramollis
