### PR TITLE
Make presenter resilient to unexpected attributes

### DIFF
--- a/decidim-module-removable_authorizations/app/presenters/decidim/removable_authorizations/admin_log/authorization_presenter.rb
+++ b/decidim-module-removable_authorizations/app/presenters/decidim/removable_authorizations/admin_log/authorization_presenter.rb
@@ -26,12 +26,12 @@ module Decidim
 
         def i18n_params
           super.merge(
-            recipient_name: recipient_presenter.present
+            recipient_name: recipient_presenter&.present
           )
         end
 
         def recipient_presenter
-          @recipient_presenter ||= Decidim::Log::UserPresenter.new(recipient, h, recipient_data)
+          @recipient_presenter ||= Decidim::Log::UserPresenter.new(recipient, h, recipient_data) if recipient_data
         end
 
         def recipient_data
@@ -39,7 +39,7 @@ module Decidim
         end
 
         def recipient
-          Decidim::User.find_by(id: recipient_data["id"])
+          Decidim::User.find_by(id: recipient_data["id"]) if recipient_data
         end
       end
     end


### PR DESCRIPTION
This PR fixes an error in the Admin log caused by the custom module removable-authorizations.

Backtracke:

```
ActionView::Template::Error undefined method `[]' for nil:NilClass
```

Snippet:

```
37         def recipient_data
38           @recipient_data ||= action_log.extra.dig("extra", "authorization_owner")
39         end
40 
41         def recipient
42           Decidim::User.find_by(id: recipient_data["id"])
43         end
44       end
45     end
46   end
```

