### PR TITLE
Remove postal code from census calls

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -11,14 +11,12 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   NORMALIZE_TELEPHONE_REGEXP = /\.|\ |\-|\_/
 
   attribute :document_number, String
-  attribute :postal_code, String
   attribute :date_of_birth, Date
   attribute :official_name_custom, String
   attribute :telephone_number_custom, String
 
   validates :date_of_birth, presence: true
   validates :document_number, presence: true
-  validates :postal_code, presence: true, format: { with: /\A[0-9]*\z/ }, length: { is: 5 }
 
   validates :official_name_custom, presence: true, length: { minimum: 3 }, if: ->(form) do
     form.user.official_name_custom.blank? && !form.user.managed
@@ -56,7 +54,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   private
 
   def user_exists_in_census
-    @census_response = CensusClient.make_request(document_number, self.class.format_birthdate(date_of_birth), postal_code)
+    @census_response = CensusClient.make_request(document_number, self.class.format_birthdate(date_of_birth))
 
     if !@census_response.registered_in_census?
       errors.add(:base, I18n.t("census_authorization.errors.messages.not_in_census"))
@@ -81,7 +79,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
     {
       email: CustomAttributeObfuscator.email(user.email),
       document_number: CustomAttributeObfuscator.document_number(document_number),
-      postal_code: CustomAttributeObfuscator.postal_code(postal_code),
       managed_user: user.managed,
       census_code: @census_response.response_code,
       census_message: census_message
@@ -92,7 +89,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
     {
       email: CustomAttributeObfuscator.email(user.email, false),
       document_number: CustomAttributeObfuscator.document_number(document_number, false),
-      postal_code: CustomAttributeObfuscator.postal_code(postal_code, false),
       managed_user: user.managed,
       census_code: @census_response.response_code,
       census_message: census_message

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -18,16 +18,6 @@
   </div>
 <% end %>
 
-<div class="field">
-  <%= form.text_field :postal_code %>
-</div>
-
-<div class="flash callout warning" style="margin-bottom: 20px">
-  <p>
-    <b>NOTA</b>: <%= t('.postal_code_help', link: link_to('http://www.correos.es', 'http://www.correos.es')).html_safe %>
-  </p>
-</div>
-
 <%= form.hidden_field :handler_name %>
 
 <% unless @form.try(:disable_submit?) %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -6,7 +6,6 @@ ca:
         date_of_birth: Data de naixement
         document_number: Número del document d'identitat (DNI o NIE sense la lletra final)
         official_name_custom: Nom oficial
-        postal_code: Codi postal
         telephone_number_custom: Telèfon personal
       user:
         official_name_custom: Nom oficial
@@ -23,7 +22,6 @@ ca:
         day: Dia
         month: Mes
         year: Any
-      postal_code_help: Si vol consultar el codi postal que té o li dona algun error al validar-lo, consulti la següent web de Correos en %{link} en l'opció cerca de codi postal; així podrà consultar el seu codi postal de l'adreça on està empadronada.
   custom_errors:
     telephone_format: Només dígits (i almenys 9)
   decidim:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,7 +6,6 @@ es:
         date_of_birth: Fecha de nacimiento
         document_number: Número del documento de identidad (DNI o NIE sin la letra final)
         official_name_custom: Nombre oficial
-        postal_code: Código postal
         telephone_number_custom: Teléfono personal
       user:
         official_name_custom: Nombre oficial
@@ -23,7 +22,6 @@ es:
         day: Día
         month: Mes
         year: Año
-      postal_code_help: Si desea consultar el código postal que tiene o le da algún error al validarlo, consulte la siguiente web de Correos en %{link} en la opción búsqueda de código postal; así podrá consultar el código postal de la dirección donde esté empadronado/a.
   custom_errors:
     telephone_format: Sólo dígitos (y al menos 9)
   decidim:

--- a/decidim-module-removable_authorizations/spec/services/decidim/dummy_authorization_handler_log_spec.rb
+++ b/decidim-module-removable_authorizations/spec/services/decidim/dummy_authorization_handler_log_spec.rb
@@ -10,7 +10,7 @@ module Decidim
 
     describe "logging" do
       let(:logged_attributes) { ActionLog.last.extra }
-      let(:extra_params) { { document_number: "12345678X", postal_code: "1" } }
+      let(:extra_params) { { document_number: "12345678X" } }
 
       before { handler.log_successful_authorization }
 
@@ -20,7 +20,6 @@ module Decidim
 
       it "logs obfuscated custom attributes" do
         expect(logged_attributes["document_number"]).to eq("1*******X")
-        expect(logged_attributes["postal_code"]).to eq("*")
       end
     end
   end

--- a/lib/custom_attribute_obfuscator.rb
+++ b/lib/custom_attribute_obfuscator.rb
@@ -10,14 +10,6 @@ class CustomAttributeObfuscator < Decidim::RemovableAuthorizations::AttributeObf
     end
   end
 
-  def self.postal_code(value, success = true)
-    if success
-      obfuscate(2, 0, value)
-    else
-      obfuscate(1, 1, value)
-    end
-  end
-
   def self.email(full_email, success = true)
     return nil unless full_email.present? && full_email.include?("@")
 

--- a/lib/reports/users_authorized.rb
+++ b/lib/reports/users_authorized.rb
@@ -1,0 +1,9 @@
+require "csv"
+
+csv = CSV.open("/tmp/verified_users_20230202_after_delete.csv", "wb") do |csv|
+  csv << %w(id email name nickname)
+  Decidim::Authorization.find_each do |a|
+    u = a.user
+    csv << [u.id, u.email, u.name, u.nickname]
+  end
+end

--- a/spec/lib/census_client_spec.rb
+++ b/spec/lib/census_client_spec.rb
@@ -19,8 +19,7 @@ describe CensusClient do
 
     let(:dni_number) { '12345678' }
     let(:birthdate) { Date.civil(1994, 12, 30).strftime('%d/%m/%Y') }
-    let(:postal_code) { '12345' }
-    let(:census_reponse) { CensusClient.make_request(dni_number, birthdate, postal_code) }
+    let(:census_reponse) { CensusClient.make_request(dni_number, birthdate) }
     let(:census_response_code) { "0" }
 
     before { stub_census_client(validarpadro_decidim_response: { result: census_response_code }) }

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -8,7 +8,6 @@ describe CensusAuthorizationHandler do
   let(:handler) { described_class.from_params(params) }
   let(:document_number) { "12345678" }
   let(:date_of_birth) { Date.civil(1987, 9, 17) }
-  let(:postal_code) { '12345' }
   let(:user) { create(:user, organization: organization) }
   let(:other_user) { create(:user, organization: organization) }
   let(:organization) { create :organization }
@@ -16,8 +15,7 @@ describe CensusAuthorizationHandler do
     {
       user: user,
       document_number: document_number,
-      date_of_birth: date_of_birth,
-      postal_code: postal_code
+      date_of_birth: date_of_birth
     }
   end
   let(:official_name) { "Napoleón Bonaparte" }
@@ -79,8 +77,7 @@ describe CensusAuthorizationHandler do
     it "avoids duplicates" do
       handler_params = {
         document_number: "12345678A",
-        date_of_birth: date_of_birth,
-        postal_code: postal_code
+        date_of_birth: date_of_birth
       }
 
       first_handler = described_class.from_params(

--- a/spec/system/verification_spec.rb
+++ b/spec/system/verification_spec.rb
@@ -24,7 +24,6 @@ describe "Verification", type: :system do
     select "12", from: "authorization_handler_date_of_birth_3i"
     select "Gener", from: "authorization_handler_date_of_birth_2i"
     select "1979", from: "authorization_handler_date_of_birth_1i"
-    fill_in "authorization_handler[postal_code]", with: "12345"
 
     if options[:with_custom_fields]
       fill_in "authorization_handler[official_name_custom]", with: official_name


### PR DESCRIPTION
This PR removes the postal code from the census authorization process. It includes:

- forms
- calls to the census api
- tests

As a result, it should produce less user errors