### PR TITLE
Frontend DNI/NIE validation

### DIFF
--- a/app/packs/src/decidim/decidim_application.js
+++ b/app/packs/src/decidim/decidim_application.js
@@ -1,0 +1,3 @@
+$(document ).ready(function() {
+  $('#new_authorization_handler #authorization_handler_document_number').attr('pattern', '^([a-zA-Z][0-9]{7})|([0-9]{8})$');
+});


### PR DESCRIPTION
This PR adds a frontend validation in the user authorization form in the DNI/NIE field using the `pattern` attribute in the input field.

It should prevent the census API to receive wrong values.

In this first iteration it's been added as a Javascript snippet.

