### PR TITLE
Census authorization issues (part 1)

### DIFF
--- a/app/packs/src/decidim/decidim_application.js
+++ b/app/packs/src/decidim/decidim_application.js
@@ -1,3 +1,3 @@
 $(document ).ready(function() {
-  $('#new_authorization_handler #authorization_handler_document_number').attr('pattern', '^([a-zA-Z][0-9]{7})|([0-9]{8})$');
+  $('#new_authorization_handler #authorization_handler_document_number').attr('pattern', '^[0-9]{8}$|^[a-zA-Z][0-9]{7}$');
 });

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -57,7 +57,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
     @census_response = CensusClient.make_request(document_number, self.class.format_birthdate(date_of_birth))
 
     if !@census_response.registered_in_census?
-      errors.add(:base, I18n.t("census_authorization.errors.messages.not_in_census"))
+      errors.add(:base, @census_response.message)
     elsif [telephone_number_custom, official_name_custom].any?(&:present?) && errors.empty?
       user.telephone_number_custom = telephone_number_custom if telephone_number_custom.present?
       user.official_name_custom = official_name_custom if official_name_custom.present?

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -19,9 +19,3 @@
 <% end %>
 
 <%= form.hidden_field :handler_name %>
-
-<% unless @form.try(:disable_submit?) %>
-  <div class="actions">
-    <%= form.submit t("authorize", scope: "decidim.verifications.new"), class: "button expanded" %>
-  </div>
-<% end %>

--- a/decidim-module-removable_authorizations/app/commands/decidim/removable_authorizations/admin/destroy_authorization.rb
+++ b/decidim-module-removable_authorizations/app/commands/decidim/removable_authorizations/admin/destroy_authorization.rb
@@ -41,14 +41,7 @@ module Decidim
         end
 
         def destroy_authorization
-          Decidim.traceability.perform_action!(
-            "delete",
-            authorization,
-            current_user,
-            extra: {
-              authorization_owner: user
-            }
-          ) do
+          Decidim.traceability.perform_action!("delete", authorization, current_user, extra: { authorization_owner: {id: user.id }}) do
             authorization.destroy
           end
         end

--- a/decidim-module-removable_authorizations/app/commands/decidim/removable_authorizations/verifications/authorize_user_overrides.rb
+++ b/decidim-module-removable_authorizations/app/commands/decidim/removable_authorizations/verifications/authorize_user_overrides.rb
@@ -3,13 +3,16 @@ module Decidim
     module Verifications
       module AuthorizeUserOverrides
         def call
-          unless handler.valid?
+          return transfer_authorization if !handler.unique? && handler.transferrable?
+
+          if handler.invalid?
             handler.log_failed_authorization
+            register_conflict
+
             return broadcast(:invalid)
           end
 
           Authorization.create_or_update_from(handler)
-
           handler.log_successful_authorization
 
           broadcast(:ok)

--- a/decidim-module-removable_authorizations/app/commands/decidim/removable_authorizations/verifications/authorize_user_overrides.rb
+++ b/decidim-module-removable_authorizations/app/commands/decidim/removable_authorizations/verifications/authorize_user_overrides.rb
@@ -3,11 +3,11 @@ module Decidim
     module Verifications
       module AuthorizeUserOverrides
         def call
-          return transfer_authorization if !handler.unique? && handler.transferrable?
-
           if handler.invalid?
+            conflict = create_verification_conflict
+            notify_admins(conflict) if conflict.present?
+
             handler.log_failed_authorization
-            register_conflict
 
             return broadcast(:invalid)
           end

--- a/decidim-module-removable_authorizations/app/presenters/decidim/removable_authorizations/admin_log/authorization_presenter.rb
+++ b/decidim-module-removable_authorizations/app/presenters/decidim/removable_authorizations/admin_log/authorization_presenter.rb
@@ -31,11 +31,17 @@ module Decidim
         end
 
         def recipient_presenter
-          @recipient_presenter ||= Decidim::Log::UserPresenter.new(recipient, h, recipient_data) if recipient_data
+          @recipient_presenter ||= Decidim::Log::UserPresenter.new(recipient, h, user_data) if recipient_data
         end
 
+        # {"extra"=>{"authorization_owner"=>{"id"=>9999}}
         def recipient_data
           @recipient_data ||= action_log.extra.dig("extra", "authorization_owner")
+        end
+
+        # {"user"=>{"ip"=>"192.168.192.161", "name"=>"Admin User", "nickname"=>"admin-user"}
+        def user_data
+          @user_data ||= action_log.extra.dig("user")
         end
 
         def recipient

--- a/decidim-module-removable_authorizations/config/locales/ca.yml
+++ b/decidim-module-removable_authorizations/config/locales/ca.yml
@@ -3,7 +3,7 @@ ca:
   decidim:
     admin:
       menu:
-        authorizations: Autoritzations
+        search_authorizations: Cercar autoritzations
     admin_log:
       authorization:
         delete: "%{user_name} ha eliminat una autorització de %{recipient_name}"

--- a/decidim-module-removable_authorizations/config/locales/en.yml
+++ b/decidim-module-removable_authorizations/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   decidim:
     admin:
       menu:
-        authorizations: Authorizations
+        search_authorizations: Search authorizations
     admin_log:
       authorization:
         delete: "%{user_name} deleted an authorization of %{recipient_name}"

--- a/decidim-module-removable_authorizations/config/locales/es.yml
+++ b/decidim-module-removable_authorizations/config/locales/es.yml
@@ -3,7 +3,7 @@ es:
   decidim:
     admin:
       menu:
-        authorizations: Autorizaciones
+        search_authorizations: Buscar autorizaciones
     admin_log:
       authorization:
         delete: "%{user_name} eliminó una autorización de %{recipient_name}"

--- a/decidim-module-removable_authorizations/lib/decidim/removable_authorizations/admin_engine.rb
+++ b/decidim-module-removable_authorizations/lib/decidim/removable_authorizations/admin_engine.rb
@@ -29,7 +29,7 @@ module Decidim
       initializer "decidim_removable_authorizations.admin_user_add_authorizations" do
         Decidim.menu :admin_user_menu do |menu|
           menu.add_item :authorizations,
-            I18n.t("menu.authorizations", scope: "decidim.admin"),
+            I18n.t("menu.search_authorizations", scope: "decidim.admin"),
             decidim_removable_authorizations_admin.authorizations_path,
             active: is_active_link?(decidim_removable_authorizations_admin.authorizations_path),
             if: allowed_to?(:delete, :authorization)

--- a/decidim-module-removable_authorizations/lib/decidim/removable_authorizations/attribute_obfuscator.rb
+++ b/decidim-module-removable_authorizations/lib/decidim/removable_authorizations/attribute_obfuscator.rb
@@ -45,6 +45,7 @@ module Decidim
 
       def self.obfuscate(plain_start_size, plan_end_size, value)
         obfuscated_length = value.length - plain_start_size - plan_end_size
+        obfuscated_length = 0 if obfuscated_length.negative?
 
         plain_start = plain_start_size.zero? ? "" : value[0..plain_start_size - 1]
         obfuscated = "*" * obfuscated_length


### PR DESCRIPTION
Closes https://github.com/AjuntamentdeReus/decidim/issues/86

This PR fixes a few issues related with authorizations and core related:

- [ ] obfuscator doesn't raise an error when the arguments are shorter than 10 chars
- [ ] avoided infinite loop when deleting an authorization
- [ ] tracks error when DNI is invalid
- [ ] removes duplicated authorize button