### PR TITLE
Update census restrictions

### DIFF
--- a/app/packs/src/decidim/decidim_application.js
+++ b/app/packs/src/decidim/decidim_application.js
@@ -1,3 +1,13 @@
-$(document ).ready(function() {
-  $('#new_authorization_handler #authorization_handler_document_number').attr('pattern', '^[0-9]{8}$|^[a-zA-Z][0-9]{7}$');
+$(document).ready(function() {
+  $('#new_authorization_handler #authorization_handler_document_number').on('focusout', function() {
+      var value = $(this).val();
+      var regex = /^[0-9]{8}$/;
+
+      if (!regex.test(value)) {
+        const message = $('html').attr('lang') == 'es' ?
+          'No tiene el formato correcto de un DNI/NIE sin la letra final. Si es un pasaporte no hagas caso de la advertencia'
+          : "No té el format correcte d'un DNI/NIE sense lletra final. Si es un passaport no facis cas de l'advertència"
+        alert(message);
+      }
+  });
 });

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -9,7 +9,7 @@
 </div>
 
 <div class="field date">
-  <%= form.date_select :date_of_birth, start_year: 1900, end_year: 13.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
+  <%= form.date_select :date_of_birth, start_year: 1900, end_year: 14.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
 </div>
 
 <% if current_user.telephone_number_custom.blank? %>

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -9,7 +9,7 @@
 </div>
 
 <div class="field date">
-  <%= form.date_select :date_of_birth, start_year: 1900, end_year: 15.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
+  <%= form.date_select :date_of_birth, start_year: 1900, end_year: 13.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
 </div>
 
 <% if current_user.telephone_number_custom.blank? %>


### PR DESCRIPTION
In this PR three requirements have been implemented:

1. Add +1 year in the calculation of available years for 2009 in the dropdown for birthdate
2. The JS validation of NIF/NIE/passport field don't block the possibility to send the form (only show alert)
3. Change the literal of the error msg to "No té el format correcte d'un DNI/NIE sense lletra final. Si es un passaport no facis cas de l'advertència" (translate for es language)