### PR TITLE
Install trusted ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "decidim-processes_admin_stats", git: "https://github.com/PopulateTools/deci
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "main"
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome.git", branch: "develop"
 gem "decidim-extra_user_fields", git: "https://github.com/PopulateTools/decidim-module-extra_user_fields.git", branch: "bump-0.28-phone-number"
+gem "decidim-trusted_ids", git: "https://github.com/PopulateTools/decidim-module-trusted-ids", branch: "upgrade-0.28"
 
 # gem "decidim-question_captcha", git: "https://github.com/OpenSourcePolitics/decidim-module-question_captcha.git", branch: "release/0.27-stable"
 gem "acts_as_textcaptcha", "~> 4.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,17 @@ GIT
       decidim-core (>= 0.26.0)
 
 GIT
+  remote: https://github.com/PopulateTools/decidim-module-trusted-ids
+  revision: de090b41c8bd2d04bca6047f01fb27f280dc7204
+  branch: upgrade-0.28
+  specs:
+    decidim-trusted_ids (0.7.0)
+      decidim (>= 0.27.0, < 0.29)
+      decidim-core (>= 0.27.0, < 0.29)
+      decidim-verifications (>= 0.27.0, < 0.29)
+      deface (>= 1.5)
+
+GIT
   remote: https://github.com/decidim-ice/decidim-module-decidim_awesome.git
   revision: b2800256f5e147452438686029b3990c89fb21be
   branch: develop
@@ -958,6 +969,7 @@ DEPENDENCIES
   decidim-processes_admin_stats!
   decidim-removable_authorizations!
   decidim-term_customizer!
+  decidim-trusted_ids!
   deface
   ed25519 (>= 1.2, < 2.0)
   faker (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/PopulateTools/decidim-module-trusted-ids
-  revision: de090b41c8bd2d04bca6047f01fb27f280dc7204
+  revision: 90126b382aabdf4d71a7f72b846b76cca866bb08
   branch: upgrade-0.28
   specs:
     decidim-trusted_ids (0.7.0)

--- a/app/controllers/concerns/decidim/extra_user_fields/include_extra_data.rb
+++ b/app/controllers/concerns/decidim/extra_user_fields/include_extra_data.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ExtraUserFields
+    # This controller customizes the behaviour of Devise::Omniauthable.
+    module IncludeExtraData
+      private
+
+      # This override takes phone number from oauth_data extra info
+      def user_params_from_oauth_hash
+        return nil if oauth_data.empty?
+
+        {
+          provider: oauth_data[:provider],
+          uid: oauth_data[:uid],
+          name: oauth_data[:info][:name],
+          nickname: oauth_data[:info][:nickname],
+          oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid]),
+          avatar_url: oauth_data[:info][:image],
+          phone_number: oauth_data[:info][:prefix] + oauth_data[:info][:phone],
+          raw_data: oauth_hash
+        }
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,9 @@ module DecidimApplication
     config.i18n.enforce_available_locales = false
     config.i18n.fallbacks = {ca: [:en], es: [:en]}
 
+    config.to_prepare do
+      Decidim::Devise::OmniauthRegistrationsController.prepend(Decidim::ExtraUserFields::IncludeExtraData)
+    end
   end
 end
 

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -201,4 +201,5 @@ NORMALIZE_TELEPHONE_REGEXP = /\.|\ |\-|\_/
 Rails.application.reloader.to_prepare do
   ::Decidim.icons.register(name: "fingerprint-2-line", icon: "fingerprint-2-line", category: "system", description: "", engine: :verifications)
   ::Decidim.icons.register(name: "message-3-line", icon: "message-3-line", category: "system", description: "", engine: :verifications)
+  ::Decidim.icons.register(name: "smartphone-line", icon: "smartphone-line", category: "system", description: "", engine: :core)
 end

--- a/config/initializers/omniauth_idcat_mobil.rb
+++ b/config/initializers/omniauth_idcat_mobil.rb
@@ -1,0 +1,12 @@
+Decidim::TrustedIds.configure do |config|
+  # The name of the omniauth provider, must be registered in Decidim.
+  config.omniauth_provider = "valid"
+  config.omniauth = {
+    enabled: true,
+    client_id: ENV["IDCAT_MOBIL_CLIENT_ID"],
+    client_secret: ENV["IDCAT_MOBIL_CLIENT_SECRET"],
+    site: ENV["IDCAT_MOBIL_SITE_URL"],
+    scope: "autenticacio_usuari",
+    icon: "smartphone-line"
+  }
+end

--- a/db/migrate/20240524135206_create_organization_trusted_ids_config.decidim_trusted_ids.rb
+++ b/db/migrate/20240524135206_create_organization_trusted_ids_config.decidim_trusted_ids.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# This migration comes from decidim_trusted_ids (originally 20230718082548)
+
+class CreateOrganizationTrustedIdsConfig < ActiveRecord::Migration[6.0]
+  def change
+    create_table :organization_trusted_ids_configs do |t|
+      t.integer :decidim_organization_id, null: false, index: { name: "index_decidim_trusted_ids_organization" }
+      t.string :handler
+      t.jsonb :settings, null: false, default: {}
+      t.integer :expiration_days
+      t.jsonb :tos, null: false, default: {}
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_14_083026) do
+ActiveRecord::Schema.define(version: 2024_05_24_135206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -576,56 +576,6 @@ ActiveRecord::Schema.define(version: 2024_05_14_083026) do
     t.index ["decidim_scope_id"], name: "index_decidim_debates_debates_on_decidim_scope_id"
     t.index ["decidim_user_group_id"], name: "index_decidim_debates_debates_on_decidim_user_group_id"
     t.index ["endorsements_count"], name: "idx_decidim_debates_debates_on_endorsemnts_count"
-  end
-
-  create_table "decidim_dummy_resources_coauthorable_dummy_resources", force: :cascade do |t|
-    t.jsonb "translatable_text"
-    t.string "title"
-    t.string "body"
-    t.text "address"
-    t.float "latitude"
-    t.float "longitude"
-    t.datetime "published_at"
-    t.integer "coauthorships_count", default: 0, null: false
-    t.integer "endorsements_count", default: 0, null: false
-    t.integer "comments_count", default: 0, null: false
-    t.bigint "decidim_component_id"
-    t.bigint "decidim_category_id"
-    t.bigint "decidim_scope_id"
-    t.string "reference"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "decidim_dummy_resources_dummy_resources", force: :cascade do |t|
-    t.jsonb "translatable_text"
-    t.jsonb "title"
-    t.string "body"
-    t.text "address"
-    t.float "latitude"
-    t.float "longitude"
-    t.datetime "published_at"
-    t.integer "coauthorships_count", default: 0, null: false
-    t.integer "endorsements_count", default: 0, null: false
-    t.integer "comments_count", default: 0, null: false
-    t.integer "follows_count", default: 0, null: false
-    t.bigint "decidim_component_id"
-    t.integer "decidim_author_id"
-    t.string "decidim_author_type"
-    t.integer "decidim_user_group_id"
-    t.bigint "decidim_category_id"
-    t.bigint "decidim_scope_id"
-    t.string "reference"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "decidim_dummy_resources_nested_dummy_resources", force: :cascade do |t|
-    t.jsonb "translatable_text"
-    t.string "title"
-    t.bigint "dummy_resource_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "decidim_editor_images", force: :cascade do |t|
@@ -1786,6 +1736,17 @@ ActiveRecord::Schema.define(version: 2024_05_14_083026) do
     t.boolean "confidential", default: true, null: false
     t.index ["decidim_organization_id"], name: "index_oauth_applications_on_decidim_organization_id"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "organization_trusted_ids_configs", force: :cascade do |t|
+    t.integer "decidim_organization_id", null: false
+    t.string "handler"
+    t.jsonb "settings", default: {}, null: false
+    t.integer "expiration_days"
+    t.jsonb "tos", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["decidim_organization_id"], name: "index_decidim_trusted_ids_organization"
   end
 
   create_table "versions", force: :cascade do |t|


### PR DESCRIPTION
Closes PopulateTools/issues#1928

### If this is a Decidim upgrade

This PR installs decidim-trusted-ids module adapted to 0.28 and configures VÀLid service on top of extra user fields addition and adds an override to OmniauthRegistrationsController to take the phone number extra user field taken from VÀLid oauth data

- [ ] If copied new migrations from Decidim with `bin/rails decidim:upgrade`
- [ ] I've ran these migrations with `bin/rails db:migrate`
- [ ] I've ran the tests with `bundle exec rspec`
- [ ] I've checked the [custom fields](https://github.com/AjuntamentdeReus/decidim/wiki/Campos-de-usuario-personalizados) continue to work as expected
- [ ] I've checked the census integration in staging
- [ ] I've checked the newsletter preferences are kept after the migrations
- [ ] I've sent a test newsletter in staging environment
- [ ] I've done general browsing both in front and backoffice, and created a test proposal
- [ ] I've reviewed the changelog and ran the necessary commands in staging
- [ ] I've checked all the new functionalities detailed in https://decidim.org/blog/ for the updated version work