### PR TITLE
Update sidekiq version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "savon"
 gem "progressbar"
 gem "deface"
 gem "letter_opener_web", "~> 1.4"
-gem "sidekiq", "~> 5.2.1"
+gem "sidekiq", "~> 5.2.10"
 
 group :development, :test do
   gem "byebug", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,7 +732,7 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     redcarpet (3.6.0)
-    redis (4.8.1)
+    redis (4.5.1)
     regexp_parser (2.9.2)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -839,11 +839,11 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    sidekiq (5.2.7)
+    sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (~> 4.5, < 4.6.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -977,7 +977,7 @@ DEPENDENCIES
   puma (>= 6.3)
   rspec
   savon
-  sidekiq (~> 5.2.1)
+  sidekiq (~> 5.2.10)
   spring
   spring-watcher-listen (~> 2.0)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
### If this is a Decidim upgrade

This PR updates sidekiq version

- [ ] If copied new migrations from Decidim with `bin/rails decidim:upgrade`
- [ ] I've ran these migrations with `bin/rails db:migrate`
- [ ] I've ran the tests with `bundle exec rspec`
- [ ] I've checked the [custom fields](https://github.com/AjuntamentdeReus/decidim/wiki/Campos-de-usuario-personalizados) continue to work as expected
- [ ] I've checked the census integration in staging
- [ ] I've checked the newsletter preferences are kept after the migrations
- [ ] I've sent a test newsletter in staging environment
- [ ] I've done general browsing both in front and backoffice, and created a test proposal
- [ ] I've reviewed the changelog and ran the necessary commands in staging
- [ ] I've checked all the new functionalities detailed in https://decidim.org/blog/ for the updated version work
