### PR TITLE
Add correct BreadcrumbHelper dependency in accountability status cell

### DIFF
--- a/config/initializers/decidim_accountability.rb
+++ b/config/initializers/decidim_accountability.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Decidim::Accountability::StatusCell.class_eval do
+  include Decidim::Accountability::BreadcrumbHelper
+end


### PR DESCRIPTION
In production environment a dependency with BreadcrumbHelper is incorrectly loaded. This PR enforces the accountability status cell to call the correct class `Decidim::Accountability::BreadcrumbHelper`