### PR TITLE
Change rails load defaults to use Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem "acts_as_textcaptcha", "~> 4.6.0"
 
 gem "bootsnap", require: false
 gem "puma", ">= 6.3"
-gem "uglifier", ">= 1.3.0"
 gem "faker", "~> 3.2"
 gem "savon"
 gem "progressbar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,7 +441,6 @@ GEM
     erubi (1.13.1)
     escape_utils (1.2.2)
     excon (1.2.3)
-    execjs (2.10.0)
     extended-markdown-filter (0.7.0)
       html-pipeline (~> 2.9)
     factory_bot (6.5.1)
@@ -905,8 +904,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     uniform_notifier (1.16.0)
@@ -996,7 +993,6 @@ DEPENDENCIES
   rspec
   savon
   sidekiq (~> 5.2.10)
-  uglifier (>= 1.3.0)
 
 RUBY VERSION
    ruby 3.1.4p223

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ Bundler.require(*Rails.groups)
 module DecidimApplication
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 6.1
 
     config.i18n.available_locales = %w(ca es en)
     config.i18n.default_locale = :en


### PR DESCRIPTION
This PR changes the load defaults fixing some errors related with the autoloading of constants