### PR TITLE
Update trusted_ids reference

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/PopulateTools/decidim-module-trusted-ids
-  revision: fbe72b764b7b021d6ac654a32674f0a19f274cd6
+  revision: abee7ee780c6497fbae21985bb7af9e6e85602db
   branch: upgrade-0.28
   specs:
     decidim-trusted_ids (0.7.0)


### PR DESCRIPTION
This PR upgrades the revision of trusted_ids gem to avoid exceptions when an organization has blank omniauth_settings attribute

### If this is a Decidim upgrade

- [ ] If copied new migrations from Decidim with `bin/rails decidim:upgrade`
- [ ] I've ran these migrations with `bin/rails db:migrate`
- [ ] I've ran the tests with `bundle exec rspec`
- [ ] I've checked the [custom fields](https://github.com/AjuntamentdeReus/decidim/wiki/Campos-de-usuario-personalizados) continue to work as expected
- [ ] I've checked the census integration in staging
- [ ] I've checked the newsletter preferences are kept after the migrations
- [ ] I've sent a test newsletter in staging environment
- [ ] I've done general browsing both in front and backoffice, and created a test proposal
- [ ] I've reviewed the changelog and ran the necessary commands in staging
- [ ] I've checked all the new functionalities detailed in https://decidim.org/blog/ for the updated version work
