### PR TITLE
Improve title representation

### DIFF
--- a/app/overrides/decidim/proposals/admin/proposals/_proposal-tr/contact_column.html.erb.deface
+++ b/app/overrides/decidim/proposals/admin/proposals/_proposal-tr/contact_column.html.erb.deface
@@ -2,7 +2,7 @@
 <td>
     <% proposal.authors.each do |author| %>
 
-      <% author_name = author.try(:name) || author.try(:title) %>
+      <% author_name = author.respond_to?(:name) ? author.name : author.try(:presenter)&.title %>
 
       <% if author.respond_to?(:extended_data) && (phone_number = author.extended_data.try(:dig, "phone_number")).present? %>
         <%= author_name %> - <%= phone_number %>


### PR DESCRIPTION
This PR improves the representation of meetings title to use its translated value

### If this is a Decidim upgrade

- [ ] If copied new migrations from Decidim with `bin/rails decidim:upgrade`
- [ ] I've ran these migrations with `bin/rails db:migrate`
- [ ] I've ran the tests with `bundle exec rspec`
- [ ] I've checked the [custom fields](https://github.com/AjuntamentdeReus/decidim/wiki/Campos-de-usuario-personalizados) continue to work as expected
- [ ] I've checked the census integration in staging
- [ ] I've checked the newsletter preferences are kept after the migrations
- [ ] I've sent a test newsletter in staging environment
- [ ] I've done general browsing both in front and backoffice, and created a test proposal
- [ ] I've reviewed the changelog and ran the necessary commands in staging
- [ ] I've checked all the new functionalities detailed in https://decidim.org/blog/ for the updated version work
